### PR TITLE
Add JSON export utilities and fix asset upload typing

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function downloadJson(data: unknown, filename: string) {
+  const json = JSON.stringify(data, null, 2)
+  const blob = new Blob([json], { type: "application/json" })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}

--- a/client/src/pages/assets.tsx
+++ b/client/src/pages/assets.tsx
@@ -729,7 +729,7 @@ export default function Assets() {
                         const uploadedFile = result.successful[0];
                         
                         // Get upload URL and file info with proper null checks
-                        const uploadUrl = uploadedFile.uploadURL || uploadedFile.url;
+                        const uploadUrl = uploadedFile.uploadURL;
                         const fileName = uploadedFile.name || uploadedFile.meta?.name || 'uploaded-file';
                         
                         if (!uploadUrl) {
@@ -966,7 +966,7 @@ export default function Assets() {
                         const uploadedFile = result.successful[0];
                         
                         // Get upload URL and file info with proper null checks
-                        const uploadUrl = uploadedFile.uploadURL || uploadedFile.url;
+                        const uploadUrl = uploadedFile.uploadURL;
                         const fileName = uploadedFile.name || uploadedFile.meta?.name || 'uploaded-file';
                         
                         if (!uploadUrl) {

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -5,6 +5,7 @@ import StatsCards from "@/components/dashboard/stats-cards";
 import RecentProjects from "@/components/dashboard/recent-projects";
 import QuickActions from "@/components/dashboard/quick-actions";
 import RecentVariants from "@/components/dashboard/recent-variants";
+import { downloadJson } from "@/lib/utils";
 
 export default function Dashboard() {
   const { data: stats, isLoading } = useQuery<DashboardStats>({
@@ -12,8 +13,9 @@ export default function Dashboard() {
   });
 
   const handleExport = () => {
-    // TODO: Implement export functionality
-    console.log("Export functionality not yet implemented");
+    if (stats) {
+      downloadJson(stats, "dashboard-stats.json");
+    }
   };
 
   return (

--- a/client/src/pages/variants.tsx
+++ b/client/src/pages/variants.tsx
@@ -12,6 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
+import { downloadJson } from "@/lib/utils";
 import { Trash2, Edit, Lightbulb, Zap, User, Download } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 
@@ -186,9 +187,17 @@ export default function Variants() {
   };
 
   const handleExport = () => {
+    if (variants.length === 0) {
+      toast({
+        title: "Export",
+        description: "No variants to export",
+      });
+      return;
+    }
+    downloadJson(variants, "variants.json");
     toast({
       title: "Export",
-      description: "Export functionality not yet implemented",
+      description: "Variants exported successfully",
     });
   };
 


### PR DESCRIPTION
## Summary
- add downloadJson helper for exporting client data
- enable exporting dashboard stats and variant lists
- remove invalid file URL fallback causing TypeScript error

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68bcee2c6a0c832eb15bcf3b7c6232cb