### PR TITLE
Fix object path for uploaded asset retrieval

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -719,7 +719,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/objects/:objectPath(*)", async (req, res) => {
     try {
       const objectStorageService = new ObjectStorageService();
-      const objectFile = await objectStorageService.getObjectEntityFile(req.path);
+      const objectPath = `/objects/${req.params.objectPath}`;
+      const objectFile = await objectStorageService.getObjectEntityFile(objectPath);
       objectStorageService.downloadObject(objectFile, res);
     } catch (error) {
       console.error("Error serving object:", error);


### PR DESCRIPTION
## Summary
- fix serving uploaded files by providing expected /objects prefix

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68bcf1c27a8c832e8db2c8e04f200915